### PR TITLE
Renamed column 'ib_hw_id' to 'infiniband_id'

### DIFF
--- a/configuration/etl/etl_action_defs.d/hardware/hosts.json
+++ b/configuration/etl/etl_action_defs.d/hardware/hosts.json
@@ -51,7 +51,7 @@
                 "name": "node",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "n",
-                "on": "ct.id = n.cpu_id AND bt.id = n.board_id AND st.id = n.system_id AND n.infiniband_device_count = s.ib_device_count AND ib.id = n.ib_hw_id AND s.gpu_device_count = n.gpu_device_count AND n.gpu_device_id = gpu.id AND n.core_count = s.core_count AND n.memory_gb = CEILING(s.physmem / 1024.0)"
+                "on": "ct.id = n.cpu_id AND bt.id = n.board_id AND st.id = n.system_id AND n.infiniband_device_count = s.ib_device_count AND ib.id = n.infiniband_id AND s.gpu_device_count = n.gpu_device_count AND n.gpu_device_id = gpu.id AND n.core_count = s.core_count AND n.memory_gb = CEILING(s.physmem / 1024.0)"
             },
             {
                 "name": "hosts",

--- a/configuration/etl/etl_action_defs.d/hardware/nodes.json
+++ b/configuration/etl/etl_action_defs.d/hardware/nodes.json
@@ -10,7 +10,7 @@
             "core_count": "s.core_count",
             "memory_gb": "CEILING(s.physmem / 1024.0)",
             "infiniband_device_count": "s.ib_device_count",
-            "ib_hw_id": "ib.id",
+            "infiniband_id": "ib.id",
             "gpu_device_count": "s.gpu_device_count",
             "gpu_device_id": "gpu.id"
         },

--- a/configuration/etl/etl_tables.d/hardware/node.json
+++ b/configuration/etl/etl_tables.d/hardware/node.json
@@ -45,7 +45,7 @@
                 "comment": "The number of InfiniBand cards present"
             },
             {
-                "name": "ib_hw_id",
+                "name": "infiniband_id",
                 "type": "int(11)",
                 "nullable": false
             },
@@ -79,7 +79,7 @@
                     "core_count",
                     "memory_gb",
                     "infiniband_device_count",
-                    "ib_hw_id",
+                    "infiniband_id",
                     "gpu_device_count",
                     "gpu_device_id"
                 ],
@@ -119,9 +119,9 @@
                 "is_unique": false
             },
             {
-                "name": "idx_ib_hw_id",
+                "name": "idx_infiniband_id",
                 "columns": [
-                    "ib_hw_id"
+                    "infiniband_id"
                 ],
                 "type": "BTREE",
                 "is_unique": false
@@ -159,9 +159,9 @@
                 ]
             },
             {
-                "name": "fk_ib_hw_id",
+                "name": "fk_infiniband_id",
                 "columns": [
-                    "ib_hw_id"
+                    "infiniband_id"
                 ],
                 "referenced_table": "infiniband_types",
                 "referenced_columns": [


### PR DESCRIPTION
Columns named `"ib_hw_id"` (foreign keys corresponding to the primary key of the `"infiniband_types"` table) have been renamed `"infiniband_id"` to be consistent with other foreign key names.