### PR TITLE
 Renamed 'node' table to 'hardware_types'

### DIFF
--- a/classes/ETL/Ingestor/HostTableTransformIngestor.php
+++ b/classes/ETL/Ingestor/HostTableTransformIngestor.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* This class iterates over a staging table (record_time_staging) in which each row pairs a 
-* host with a hardware configuration at a specific time (record_time). 
+* This class iterates over a staging table (record_time_staging) in which each row pairs a
+* host with a hardware configuration at a specific time (record_time).
 * The transformation will associate each host with a specific hardware configuration
 * over a *range* of times (start_time and end_time)
-* 
+*
 * @author Max Dudek <maxdudek@gmail.com>
 * @date 2019-05-20
 */
@@ -24,7 +24,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 {
 
     /**
-     * @var $_instance_state an array representing a row to be added to the host table - 
+     * @var $_instance_state an array representing a row to be added to the host table -
      * it associates a host with a hardware configuration during a period of time
      */
     private $_instance_state;
@@ -41,7 +41,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 
     /**
      * Create a new row and associate it with the current record on the staging table
-     * 
+     *
      * @param $srcRecord the current row from the staging table being read
      */
     private function initInstance(array $srcRecord)
@@ -58,7 +58,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 
     /**
      * Update the end_time of the current instance_state to match with the current record
-     * 
+     *
      * @param $srcRecord the current row from the staging table being read
      */
     private function updateInstance(array $srcRecord)
@@ -69,13 +69,13 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 
     /**
      * @see ETL\Ingestor\pdoIngestor::transform()
-     * 
+     *
      * This function gets called on every row in the record_time_staging table.
      * If the row represents a new hardware/host pairing, then a new instance will be created.
      * Otherwise, the current instance will be updated.
-     * 
+     *
      * @param $srcRecord The current row from the staging table
-     * 
+     *
      * @return array The final instance_state if the hardware changes, 
      * or an empty array otherwise
      */
@@ -112,7 +112,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
      * Generates an SQL query which is used on the staging table (record_time_staging)
      * to generate the source table which is iterated through. A dummy row of zeros is added
      * at the end, and the table is sorted by host and time.
-     * 
+     *
      * @return string the SQL query
      */
     protected function getSourceQueryString()

--- a/classes/ETL/Ingestor/HostTableTransformIngestor.php
+++ b/classes/ETL/Ingestor/HostTableTransformIngestor.php
@@ -76,7 +76,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
      *
      * @param $srcRecord The current row from the staging table
      *
-     * @return array The final instance_state if the hardware changes, 
+     * @return array The final instance_state if the hardware changes,
      * or an empty array otherwise
      */
     protected function transform(array $srcRecord, &$orderId)

--- a/classes/ETL/Ingestor/HostTableTransformIngestor.php
+++ b/classes/ETL/Ingestor/HostTableTransformIngestor.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* This class iterates over a staging table (record_time_staging) in which each row pairs a
-* host with a hardware configuration at a specific time (record_time).
+* This class iterates over a staging table (record_time_staging) in which each row pairs a 
+* host with a hardware configuration at a specific time (record_time). 
 * The transformation will associate each host with a specific hardware configuration
 * over a *range* of times (start_time and end_time)
-*
+* 
 * @author Max Dudek <maxdudek@gmail.com>
 * @date 2019-05-20
 */
@@ -24,7 +24,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 {
 
     /**
-     * @var $_instance_state an array representing a row to be added to the host table -
+     * @var $_instance_state an array representing a row to be added to the host table - 
      * it associates a host with a hardware configuration during a period of time
      */
     private $_instance_state;
@@ -41,14 +41,14 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 
     /**
      * Create a new row and associate it with the current record on the staging table
-     *
+     * 
      * @param $srcRecord the current row from the staging table being read
      */
     private function initInstance(array $srcRecord)
     {
         $this->_instance_state = array(
             'host_id' => $srcRecord['host_id'],
-            'node_id' => $srcRecord['node_id'],
+            'hardware_id' => $srcRecord['hardware_id'],
             'start_time' => $srcRecord['record_time'],
             'start_day_id' => $srcRecord['record_day_id'],
             'end_time' => $srcRecord['record_time'],
@@ -58,7 +58,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 
     /**
      * Update the end_time of the current instance_state to match with the current record
-     *
+     * 
      * @param $srcRecord the current row from the staging table being read
      */
     private function updateInstance(array $srcRecord)
@@ -69,14 +69,14 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 
     /**
      * @see ETL\Ingestor\pdoIngestor::transform()
-     *
+     * 
      * This function gets called on every row in the record_time_staging table.
      * If the row represents a new hardware/host pairing, then a new instance will be created.
      * Otherwise, the current instance will be updated.
-     *
+     * 
      * @param $srcRecord The current row from the staging table
-     *
-     * @return array The final instance_state if the hardware changes,
+     * 
+     * @return array The final instance_state if the hardware changes, 
      * or an empty array otherwise
      */
     protected function transform(array $srcRecord, &$orderId)
@@ -98,8 +98,8 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
 
         $transformedRecord = array();
 
-        // If the host or the node changes, create a new instance
-        if (($this->_instance_state['node_id'] !== $srcRecord['node_id']) || ($this->_instance_state['host_id'] !== $srcRecord['host_id'])) {
+        // If the host or the hardware changes, create a new instance
+        if (($this->_instance_state['hardware_id'] !== $srcRecord['hardware_id']) || ($this->_instance_state['host_id'] !== $srcRecord['host_id'])) {
             $transformedRecord[] = $this->_instance_state;
             $this->initInstance($srcRecord);
         } else {
@@ -112,7 +112,7 @@ class HostTableTransformIngestor extends pdoIngestor implements iAction
      * Generates an SQL query which is used on the staging table (record_time_staging)
      * to generate the source table which is iterated through. A dummy row of zeros is added
      * at the end, and the table is sorted by host and time.
-     *
+     * 
      * @return string the SQL query
      */
     protected function getSourceQueryString()

--- a/configuration/etl/etl.d/hardware.json
+++ b/configuration/etl/etl.d/hardware.json
@@ -48,9 +48,9 @@
             1062
         ]
     }, {
-        "name": "nodes",
-        "description": "Populate the node table",
-        "definition_file": "hardware/nodes.json"
+        "name": "hardware_types",
+        "description": "Populate the hardware types table",
+        "definition_file": "hardware/hardware_types.json"
     }, {
         "name": "record_time_staging",
         "description": "Populate the record_time_staging table",

--- a/configuration/etl/etl_action_defs.d/hardware/hardware_types.json
+++ b/configuration/etl/etl_action_defs.d/hardware/hardware_types.json
@@ -1,6 +1,6 @@
 {
     "table_definition": [{
-        "$ref": "${table_definition_dir}/hardware/node.json#/table_definition"
+        "$ref": "${table_definition_dir}/hardware/hardware_types.json#/table_definition"
     }],
     "source_query": {
         "records": {

--- a/configuration/etl/etl_action_defs.d/hardware/hosts.json
+++ b/configuration/etl/etl_action_defs.d/hardware/hosts.json
@@ -5,7 +5,7 @@
     "destination_record_map": {
         "host": {
             "host_id": "host_id",
-            "node_id": "node_id",
+            "hardware_id": "hardware_id",
             "start_time": "start_time",
             "end_time": "end_time",
             "start_day_id": "start_day_id",
@@ -15,9 +15,9 @@
     "source_query": {
         "records": {
             "host_id": "s.host_id",
-            "node_id": "s.node_id",
-            "record_time": "FROM_UNIXTIME(s.record_time)",
-            "record_day_id": "DATE_FORMAT(FROM_UNIXTIME(s.record_time), '%Y00%j')",
+            "hardware_id": "s.hardware_id",
+            "record_time": "FROM_UNIXTIME(s.record_time_ts)",
+            "record_day_id": "DATE_FORMAT(FROM_UNIXTIME(s.record_time_ts), '%Y00%j')",
             "start_time": -1,
             "end_time": -1,
             "start_day_id": -1,

--- a/configuration/etl/etl_action_defs.d/hardware/record_time_staging.json
+++ b/configuration/etl/etl_action_defs.d/hardware/record_time_staging.json
@@ -5,8 +5,8 @@
     "source_query": {
         "records": {
             "host_id": "h.id",
-            "node_id": "n.id",
-            "record_time": "s.record_time"
+            "hardware_id": "hw.id",
+            "record_time_ts": "s.record_time_ts"
         },
         "joins": [
             {
@@ -45,10 +45,10 @@
                 "on": "s.gpu_device_manufacturer = gpu.manufacturer AND s.gpu_device_name = gpu.name"
             },
             {
-                "name": "node",
+                "name": "hardware_types",
                 "schema": "${SOURCE_SCHEMA}",
-                "alias": "n",
-                "on": "ct.id = n.cpu_id AND bt.id = n.board_id AND st.id = n.system_id AND n.infiniband_device_count = s.ib_device_count AND ib.id = n.infiniband_id AND s.gpu_device_count = n.gpu_device_count AND n.gpu_device_id = gpu.id AND n.core_count = s.core_count AND n.memory_gb = CEILING(s.physmem / 1024.0)"
+                "alias": "hw",
+                "on": "ct.id = hw.cpu_id AND bt.id = hw.board_id AND st.id = hw.system_id AND hw.infiniband_device_count = s.ib_device_count AND ib.id = hw.infiniband_id AND s.gpu_device_count = hw.gpu_device_count AND hw.gpu_device_id = gpu.id AND hw.core_count = s.core_count AND hw.memory_gb = CEILING(s.physmem / 1024.0)"
             },
             {
                 "name": "hosts",

--- a/configuration/etl/etl_tables.d/hardware/hardware_types.json
+++ b/configuration/etl/etl_tables.d/hardware/hardware_types.json
@@ -1,6 +1,6 @@
 {
     "table_definition": {
-        "name": "node",
+        "name": "hardware_types",
         "engine": "InnoDB",
         "charset": "utf8",
         "collation": "utf8_unicode_ci",

--- a/configuration/etl/etl_tables.d/hardware/host.json
+++ b/configuration/etl/etl_tables.d/hardware/host.json
@@ -11,7 +11,7 @@
                 "nullable": false
             },
             {
-                "name": "node_id",
+                "name": "hardware_id",
                 "type": "int(11)",
                 "nullable": false
             },
@@ -41,7 +41,7 @@
                 "name": "PRIMARY",
                 "columns": [
                     "host_id",
-                    "node_id",
+                    "hardware_id",
                     "start_day_id",
                     "end_day_id"
                 ],
@@ -49,9 +49,9 @@
                 "is_unique": true
             },
             {
-                "name": "idx_node_id",
+                "name": "idx_hardware_id",
                 "columns": [
-                    "node_id"
+                    "hardware_id"
                 ],
                 "type": "BTREE",
                 "is_unique": false
@@ -60,7 +60,7 @@
                 "name": "idx_time",
                 "columns": [
                     "host_id",
-                    "node_id",
+                    "hardware_id",
                     "start_day_id"
                 ],
                 "type": "BTREE",
@@ -69,11 +69,11 @@
         ],
         "foreign_key_constraints": [
             {
-                "name": "fk_node_id",
+                "name": "fk_hardware_id",
                 "columns": [
-                    "node_id"
+                    "hardware_id"
                 ],
-                "referenced_table": "node",
+                "referenced_table": "hardware_types",
                 "referenced_columns": [
                     "id"
                 ]

--- a/configuration/etl/etl_tables.d/hardware/record_time_staging.json
+++ b/configuration/etl/etl_tables.d/hardware/record_time_staging.json
@@ -11,12 +11,12 @@
                 "nullable": false
             },
             {
-                "name": "node_id",
+                "name": "hardware_id",
                 "type": "int(11)",
                 "nullable": false
             },
             {
-                "name": "record_time",
+                "name": "record_time_ts",
                 "type": "float(32)",
                 "nullable": false
             }
@@ -26,8 +26,8 @@
                 "name": "PRIMARY",
                 "columns": [
                     "host_id",
-                    "node_id",
-                    "record_time"
+                    "hardware_id",
+                    "record_time_ts"
                 ],
                 "type": "BTREE",
                 "is_unique": true
@@ -36,7 +36,7 @@
                 "name": "idx_host_id",
                 "columns": [
                     "host_id",
-                    "record_time"
+                    "record_time_ts"
                 ],
                 "type": "BTREE",
                 "is_unique": false

--- a/configuration/etl/etl_tables.d/hardware/staging.json
+++ b/configuration/etl/etl_tables.d/hardware/staging.json
@@ -111,7 +111,7 @@
                 "nullable": false
             },
             {
-                "name": "record_time",
+                "name": "record_time_ts",
                 "type": "float(32)",
                 "nullable": false
             }

--- a/tests/integration_tests/scripts/host_ingest_test.py
+++ b/tests/integration_tests/scripts/host_ingest_test.py
@@ -3,12 +3,12 @@ import json
 SECONDS_PER_DAY = 86400
 START_TIME = 1500000000
 
-def associate(host_num, node_num, num_days):
-    """Associate a host with a node (hardware configuration)
+def associate(host_num, hw_num, num_days):
+    """Associate a host with a hardware configuration
     for a certain amount of time"""
     end_time = currentTimeOf[host_num] + num_days*SECONDS_PER_DAY
-    for record_time in range(currentTimeOf[host_num], end_time, SECONDS_PER_DAY):
-        newRow = [hosts[host_num]] + nodes[node_num] + [record_time]
+    for record_time_ts in range(currentTimeOf[host_num], end_time, SECONDS_PER_DAY):
+        newRow = [hosts[host_num]] + hw_types[hw_num] + [record_time_ts]
         result.append(newRow)
     currentTimeOf[host_num] = end_time
 
@@ -36,7 +36,7 @@ result = [
         'gpu_device_count',
         'gpu_device_manufacturer',
         'gpu_device_name',
-        'record_time',
+        'record_time_ts',
     ]
 ]
 
@@ -49,7 +49,7 @@ currentTimeOf = []
 for host_num in range(len(hosts)):
     currentTimeOf.append(START_TIME)
 
-nodes = [
+hw_types = [
     [
         "INTEL",
         "Westmere EP",


### PR DESCRIPTION
`node_id` columns have also been renamed to `hardware_id` to better indicate what the column represents (the id of a unique hardware configuration).

Additionally, `record_time` columns which are in a Unix timestamp format have been renamed to `record_time_ts` to be consistent with convention.